### PR TITLE
use _ for first value needed in range expression

### DIFF
--- a/birthday.go
+++ b/birthday.go
@@ -64,8 +64,8 @@ func main() {
 	// TODO: display birthdays this week
 
 	// TODO: look into `range`
-	for i := range configs {
-		fmt.Println(configs[i].Name, configs[i].Birthday.Format(readableBirthdayLayout), configs[i].Twitter, configs[i].Location) // output
+	for _, v := range configs {
+		fmt.Println(v.Name, v.Birthday.Format(readableBirthdayLayout), v.Twitter, v.Location) // output
 	}
 
 }


### PR DESCRIPTION
https://github.com/golang/go/wiki/Range

the magic of range for arrays to omit superfluous repetition in loop declaration and bodies and multiple variable constructs for referencing elements of an array. 

don't forget `_` as the golang syntax for skipping the unused `i` in the for expression (to the left of range) to make the compiler happy, because it must take `i` as talked about in the link above, before it can take `v`. 

Other things to remember: 
range _automatically_ knew to take `len(configs)`, without explicitly needing to be told as part of the condition expression https://tour.golang.org/flowcontrol/1  - otherwise [a specific array int value would be declared](https://github.com/careops/birthday/commit/61544279cdd9e91c82d0e56f553cbbb404d055f4#diff-c51cdee720726072c88d8efe6ffa0263L64), and that is very brittle code (not enough elements in array, too many elements, etc. etc) which would require changes to be made every time an object was added to the `config.json`

### one last note 
when learning the power and awesomeness of `range`, it's better to experience or manually go through the things `range` aims to simplify within `for`. 